### PR TITLE
Make gas_price endpoint public

### DIFF
--- a/lighter/modules/api.py
+++ b/lighter/modules/api.py
@@ -168,7 +168,7 @@ class AsyncApi(BaseApi):
             False,
         )
 
-    async def _get_gas_price(self) -> dict:
+    async def get_gas_price(self) -> dict:
         uri = "/gas_price"
         return await self._get(
             uri,
@@ -316,7 +316,7 @@ class Api(BaseApi):
             False,
         )
 
-    def _get_gas_price(self) -> dict:
+    def get_gas_price(self) -> dict:
         uri = "/gas_price"
         return self._get(
             uri,

--- a/lighter/modules/blockchain.py
+++ b/lighter/modules/blockchain.py
@@ -1028,7 +1028,7 @@ class AsyncBlockchain(BaseBlockchain):
         ]
 
     async def _get_gas_price(self) -> int:
-        return (await self._api._get_gas_price())["gas_price"]
+        return (await self._api.get_gas_price())["gas_price"]
 
     async def get_eth_balance(
         self,
@@ -1671,7 +1671,7 @@ class Blockchain(BaseBlockchain):
         ]
 
     def _get_gas_price(self) -> int:
-        return self._api._get_gas_price()["gas_price"]
+        return self._api.get_gas_price()["gas_price"]
 
     def get_eth_balance(
         self,


### PR DESCRIPTION
Since it's in our public APIs. I made it publicly accessible.

Sample Run:
<img width="334" alt="Screenshot 2023-06-12 at 15 50 31" src="https://github.com/elliottech/lighter-v1-python/assets/25604165/dc4fcff4-8a30-405a-96e3-d76a2134ccbd">
